### PR TITLE
fix: Missing deploymentMode on Message

### DIFF
--- a/src/CXml/Builder.php
+++ b/src/CXml/Builder.php
@@ -128,7 +128,7 @@ class Builder
                 /** @noinspection PhpParamsInspection */
                 $cXml = CXml::forMessage(
                     $this->payloadIdentityFactory->newPayloadIdentity(),
-                    new Message($this->payload, $this->status),
+                    new Message($this->payload, $this->status, null, $deploymentMode),
                     $this->buildHeader(),
                     $this->locale,
                 );


### PR DESCRIPTION
While using the lib I found that `deploymentMode` was missing on the Builder.
Let me know if it is intended, and otherwise a fix proposal could be this.

Also, I may have missed other places where the same kind of adaptation should be made, I don't have the full scope of the lib in mind, you may want to have a second look.

Have a good day :) 