### PR TITLE
Update composer Q2-2025 [PHPSTAN v2, Rector V2]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,16 +56,16 @@ jobs:
         run: vendor/bin/parallel-lint src/
 
       - name: Run CodeStyle checks
-        run: composer run cs-check
+        run: composer run cs:check
 
-      - name: Run PHPStan
-        run: composer run phpstan
+      - name: Run PHPStan check
+        run: composer run phpstan:check
 
-      - name: Run Rector
-        run: composer run rector-check
+      - name: Run Rector check
+        run: composer run rector:check
 
-      - name: Run Tests
-        run: composer run test
+      - name: Run PhpUnit tests
+        run: composer run phpunit:test
 
       - name: Run Security check
-        run: composer run security-check
+        run: composer run security:check

--- a/composer.json
+++ b/composer.json
@@ -38,17 +38,18 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^11",
-    "phpstan/phpstan": "^1.11.0",
+    "phpstan/phpstan": "^2.0",
     "friendsofphp/php-cs-fixer": "*",
     "php-parallel-lint/php-parallel-lint": "*",
     "enlightn/security-checker": "*",
     "symfony/routing": "^4.4.44 || ^5.0.0 || ^6.0.0 || ^7.0.0",
-    "rector/rector": "^1.1",
-    "phpstan/extension-installer": "^1.3",
-    "phpstan/phpstan-strict-rules": "^1.6",
-    "phpstan/phpstan-deprecation-rules": "^1.2",
-    "goetas/jms-serializer-phpstan-extension": "^1.0",
-    "tomasvotruba/type-coverage": "^0.3.0 || ^1.0.0"
+    "rector/rector": "^2.0",
+    "phpstan/extension-installer": "^1.4.0",
+    "phpstan/phpstan-strict-rules": "^2.0",
+    "phpstan/phpstan-deprecation-rules": "^2.0",
+    "goetas/jms-serializer-phpstan-extension": "^1.3.0",
+    "tomasvotruba/type-coverage": "^2.0",
+    "phpstan/phpstan-beberlei-assert": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -62,13 +62,29 @@
     }
   },
   "scripts": {
-    "test": "vendor/bin/phpunit --testdox tests",
-    "cs-check": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer check --diff",
-    "cs-fix": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --diff",
-    "phpstan": "vendor/bin/phpstan analyze",
-    "rector-check": "vendor/bin/rector process --dry-run",
-    "rector": "vendor/bin/rector process",
-    "security-check": "vendor/bin/security-checker security:check composer.lock"
+    "phpunit:test": "vendor/bin/phpunit --testdox tests",
+    "cs:check": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer check --diff",
+    "cs:fix": "PHP_CS_FIXER_IGNORE_ENV=1 vendor/bin/php-cs-fixer fix --diff",
+    "phpstan:check": "vendor/bin/phpstan analyze",
+    "rector:check": "vendor/bin/rector process --dry-run",
+    "rector:fix": "vendor/bin/rector process",
+    "security:check": "vendor/bin/security-checker security:check composer.lock",
+    "run:all": [
+      "@phpunit:test",
+      "@cs:check",
+      "@cs:fix",
+      "@phpstan:check",
+      "@rector:check",
+      "@rector:fix",
+      "@security:check"
+    ],
+    "test:all": [
+      "@phpunit:test",
+      "@cs:check",
+      "@phpstan:check",
+      "@rector:check",
+      "@security:check"
+    ]
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "symfony/routing": "If you want to use SelfAwareProfileRequestHandler"
   },
   "require-dev": {
-    "phpunit/phpunit": "^12",
+    "phpunit/phpunit": "^11.0 || ^12.0",
     "phpstan/phpstan": "^2.0",
     "friendsofphp/php-cs-fixer": "*",
     "php-parallel-lint/php-parallel-lint": "*",
@@ -73,6 +73,9 @@
   "config": {
     "allow-plugins": {
       "phpstan/extension-installer": true
+    },
+    "platform": {
+      "php": "8.2.28"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-simplexml": "*",
     "ext-dom": "*",
     "ext-libxml": "*",
-    "beberlei/assert": "@stable",
+    "beberlei/assert": "^2.0 || ^3.0",
     "jms/serializer": "^3.30.0",
     "psr/log": "^1.0 || ^2.0 || ^3.0",
     "psr/event-dispatcher": "^1.0.0"
@@ -37,7 +37,7 @@
     "symfony/routing": "If you want to use SelfAwareProfileRequestHandler"
   },
   "require-dev": {
-    "phpunit/phpunit": "^11",
+    "phpunit/phpunit": "^12",
     "phpstan/phpstan": "^2.0",
     "friendsofphp/php-cs-fixer": "*",
     "php-parallel-lint/php-parallel-lint": "*",

--- a/rector.php
+++ b/rector.php
@@ -44,7 +44,7 @@ return RectorConfig::configure()
     ])
     ->withFileExtensions(['php'])
     ->withCache(
-        cacheDirectory: '/tmp/rector',
+        cacheDirectory: '/tmp/rector-cxml-php',
         cacheClass: FileCacheStorage::class,
     )
     ->withParallel(

--- a/src/CXml/Builder.php
+++ b/src/CXml/Builder.php
@@ -31,6 +31,9 @@ use LogicException;
 class Builder
 {
     // according to cXML reference document
+    /**
+     * @var array<class-string<CXmlException>, int>
+     */
     private static array $exceptionMapping = [
         CXmlAuthenticationInvalidException::class => 401,
         CXmlNotAcceptableException::class => 406,
@@ -42,6 +45,9 @@ class Builder
     ];
 
     // TODO create enum for this?
+    /**
+     * @var array<int, string>
+     */
     private static array $exceptionCodeMapping = [
         // cxml
         450 => 'Not Implemented',

--- a/src/CXml/Builder/ProductActivityMessageBuilder.php
+++ b/src/CXml/Builder/ProductActivityMessageBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXml\Builder;
 
+use Assert\Assertion;
 use CXml\Model\Contact;
 use CXml\Model\Inventory;
 use CXml\Model\InventoryQuantity;
@@ -43,6 +44,8 @@ readonly class ProductActivityMessageBuilder
 
         if (null !== $extrinsics && [] !== $extrinsics) {
             foreach ($extrinsics as $k => $v) {
+                Assertion::string($k, 'Extrinsics key must be a string');
+                Assertion::string($v, 'Extrinsics value must be a string');
                 $activityDetail->addExtrinsicAsKeyValue($k, $v);
             }
         }

--- a/src/CXml/Builder/PunchOutOrderMessageBuilder.php
+++ b/src/CXml/Builder/PunchOutOrderMessageBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXml\Builder;
 
+use Assert\Assertion;
 use CXml\Model\Address;
 use CXml\Model\Description;
 use CXml\Model\ItemDetail;
@@ -68,7 +69,7 @@ class PunchOutOrderMessageBuilder
         ?string $carrierShippingMethod = null,
     ): self {
         $transportInformation = null;
-        if (null !== $carrierAccountNo || null != $carrierShippingMethod) {
+        if (null !== $carrierAccountNo || null !== $carrierShippingMethod) {
             $transportInformation = TransportInformation::create($carrierAccountNo, $carrierShippingMethod);
         }
 
@@ -81,6 +82,8 @@ class PunchOutOrderMessageBuilder
         );
 
         foreach ($carrierIdentifiers as $domain => $identifier) {
+            Assertion::string($domain, 'Carrier identifier domain must be a string');
+            Assertion::string($identifier, 'Carrier identifier must be a string');
             $this->shipTo->addCarrierIdentifier($domain, $identifier);
         }
 
@@ -148,6 +151,8 @@ class PunchOutOrderMessageBuilder
 
         if (null !== $extrinsics && [] !== $extrinsics) {
             foreach ($extrinsics as $k => $v) {
+                Assertion::string($k, 'Extrinsics key must be a string');
+                Assertion::string($v, 'Extrinsics value must be a string');
                 $itemDetail->addExtrinsicAsKeyValue($k, $v);
             }
         }

--- a/src/CXml/Context.php
+++ b/src/CXml/Context.php
@@ -39,7 +39,7 @@ class Context
 
     public function isDryRun(): bool
     {
-        return $this->options['dryrun'] ?? false;
+        return (bool) $this->getOption('dryrun');
     }
 
     public function getCXml(): ?CXml

--- a/src/CXml/Context.php
+++ b/src/CXml/Context.php
@@ -39,7 +39,7 @@ class Context
 
     public function isDryRun(): bool
     {
-        return (bool) $this->getOption('dryrun');
+        return (bool)$this->getOption('dryrun');
     }
 
     public function getCXml(): ?CXml

--- a/src/CXml/Jms/CXmlWrappingNodeJmsEventSubscriber.php
+++ b/src/CXml/Jms/CXmlWrappingNodeJmsEventSubscriber.php
@@ -150,6 +150,7 @@ class CXmlWrappingNodeJmsEventSubscriber implements EventSubscriberInterface
             if (!$payloadNode instanceof SimpleXMLElement) {
                 return;
             }
+
             $serializedName = $payloadNode->getName();
             $cls = $this->modelClassMapping->findClassForSerializedName($serializedName);
 

--- a/src/CXml/Jms/JmsDateTimeHandler.php
+++ b/src/CXml/Jms/JmsDateTimeHandler.php
@@ -26,16 +26,16 @@ class JmsDateTimeHandler
     {
         $format = $date instanceof Date ? 'Y-m-d' : $this->getFormat($type);
 
-        /** @phpstan-ignore-next-line */
+        /* @phpstan-ignore-next-line */
         return $visitor->visitSimpleString($date->format($format), $type);
     }
 
     private function getFormat(array $type): string
     {
-        if (isset($type['params']) && is_array($type['params']) && count($type['params']) > 0) {
+        if (isset($type['params']) && is_array($type['params']) && [] !== $type['params']) {
             $format = $type['params'][0] ?? null;
 
-            if (is_string($format) && $format !== '') {
+            if (is_string($format) && '' !== $format) {
                 return $format;
             }
         }
@@ -47,10 +47,8 @@ class JmsDateTimeHandler
     public function deserialize(XmlDeserializationVisitor $visitor, SimpleXMLElement $dateAsString, array $type, Context $context): DateTime|false
     {
         // explicit date-format was defined in property annotation
-        if (isset($type['params']) && is_array($type['params']) && count($type['params']) > 0) {
-            if (isset($type['params'][0]) && is_string($type['params'][0]) && $type['params'][0] !== '') {
-                return DateTime::createFromFormat($type['params'][0], $dateAsString->__toString());
-            }
+        if (isset($type['params']) && is_array($type['params']) && [] !== $type['params'] && (isset($type['params'][0]) && is_string($type['params'][0]) && '' !== $type['params'][0])) {
+            return DateTime::createFromFormat($type['params'][0], $dateAsString->__toString());
         }
 
         // else try ISO-8601

--- a/src/CXml/Jms/JmsDateTimeHandler.php
+++ b/src/CXml/Jms/JmsDateTimeHandler.php
@@ -18,7 +18,7 @@ use SimpleXMLElement;
  * We need a custom DateTime Handler to allow multiple different DateTime versions.
  *
  * Although the cXML documentation defines ISO-8601 as the primary date format, there are cXML implementations
- * which uses milliseconds or a simple date-only format. (i.e. https://www.jaggaer.com/)
+ * that use milliseconds or a simple date-only format. (i.e., https://www.jaggaer.com/)
  */
 class JmsDateTimeHandler
 {
@@ -26,19 +26,31 @@ class JmsDateTimeHandler
     {
         $format = $date instanceof Date ? 'Y-m-d' : $this->getFormat($type);
 
+        /** @phpstan-ignore-next-line */
         return $visitor->visitSimpleString($date->format($format), $type);
     }
 
     private function getFormat(array $type): string
     {
-        return $type['params'][0] ?? DateTimeInterface::ATOM;
+        if (isset($type['params']) && is_array($type['params']) && count($type['params']) > 0) {
+            $format = $type['params'][0] ?? null;
+
+            if (is_string($format) && $format !== '') {
+                return $format;
+            }
+        }
+
+        // if no format was defined, use ISO-8601 as default
+        return DateTimeInterface::ATOM;
     }
 
     public function deserialize(XmlDeserializationVisitor $visitor, SimpleXMLElement $dateAsString, array $type, Context $context): DateTime|false
     {
         // explicit date-format was defined in property annotation
-        if (isset($type['params'][0])) {
-            return DateTime::createFromFormat($type['params'][0], $dateAsString->__toString());
+        if (isset($type['params']) && is_array($type['params']) && count($type['params']) > 0) {
+            if (isset($type['params'][0]) && is_string($type['params'][0]) && $type['params'][0] !== '') {
+                return DateTime::createFromFormat($type['params'][0], $dateAsString->__toString());
+            }
         }
 
         // else try ISO-8601

--- a/src/CXml/Jms/ModelClassMapping.php
+++ b/src/CXml/Jms/ModelClassMapping.php
@@ -15,6 +15,9 @@ use Throwable;
 
 class ModelClassMapping
 {
+    /**
+     * @var array<string, class-string|string>
+     */
     private static array $modelRegistry = [];
 
     public static bool $initialized = false;
@@ -26,7 +29,7 @@ class ModelClassMapping
         );
     }
 
-    public function __construct(private string $pathToModelFiles)
+    public function __construct(private readonly string $pathToModelFiles)
     {
     }
 

--- a/src/CXml/Model/Extrinsic.php
+++ b/src/CXml/Model/Extrinsic.php
@@ -11,7 +11,7 @@ readonly class Extrinsic
     public function __construct(
         #[Serializer\XmlAttribute]
         public string $name,
-        #[Serializer\XmlValue(cdata: false)]
+        #[Serializer\XmlValue]
         public string $value,
     ) {
     }

--- a/src/CXml/Model/ItemIn.php
+++ b/src/CXml/Model/ItemIn.php
@@ -14,7 +14,7 @@ readonly class ItemIn
         #[Serializer\SerializedName('quantity')]
         public int $quantity,
         #[Serializer\SerializedName('ItemID')]
-        public ?ItemId $itemId,
+        public ItemId $itemId,
         #[Serializer\SerializedName('ItemDetail')]
         public ItemDetail $itemDetail,
     ) {

--- a/src/CXml/Model/Money.php
+++ b/src/CXml/Model/Money.php
@@ -17,9 +17,9 @@ readonly class Money
         #[Serializer\XmlAttribute]
         public string $currency,
         #[Serializer\Exclude]
-        public int $valueCent,
+        public ?int $valueCent = null,
     ) {
-        $this->value = number_format($this->valueCent / 100, 2, '.', '');
+        $this->value = number_format((int)$this->valueCent / 100, 2, '.', '');
     }
 
     public function getValueCent(): int

--- a/src/CXml/Model/PostalAddress.php
+++ b/src/CXml/Model/PostalAddress.php
@@ -51,8 +51,8 @@ class PostalAddress
     {
         return
             (null === $this->name || '' === $this->name || '0' === $this->name)
-            && [] === array_filter($this->deliverTo, function ($value) {return '' !== $value && '0' !== $value;})
-            && [] === array_filter($this->street, function ($value) {return '' !== $value && '0' !== $value;})
+            && [] === array_filter($this->deliverTo, function ($value): bool {return '' !== $value && '0' !== $value; })
+            && [] === array_filter($this->street, function ($value): bool {return '' !== $value && '0' !== $value; })
             && ('' === $this->city || '0' === $this->city)
             && (null === $this->municipality || '' === $this->municipality || '0' === $this->municipality)
             && (null === $this->state || '' === $this->state || '0' === $this->state)

--- a/src/CXml/Model/PostalAddress.php
+++ b/src/CXml/Model/PostalAddress.php
@@ -51,8 +51,8 @@ class PostalAddress
     {
         return
             (null === $this->name || '' === $this->name || '0' === $this->name)
-            && [] === array_filter($this->deliverTo)
-            && [] === array_filter($this->street)
+            && [] === array_filter($this->deliverTo, function ($value) {return '' !== $value && '0' !== $value;})
+            && [] === array_filter($this->street, function ($value) {return '' !== $value && '0' !== $value;})
             && ('' === $this->city || '0' === $this->city)
             && (null === $this->municipality || '' === $this->municipality || '0' === $this->municipality)
             && (null === $this->state || '' === $this->state || '0' === $this->state)

--- a/src/CXml/Model/Request/OrderRequest.php
+++ b/src/CXml/Model/Request/OrderRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXml\Model\Request;
 
+use Assert\Assertion;
 use CXml\Model\ItemOut;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -31,6 +32,8 @@ class OrderRequest implements RequestPayloadInterface
 
     public function addItems(array $items): self
     {
+        Assertion::allIsInstanceOf($items, ItemOut::class);
+
         foreach ($items as $item) {
             $this->addItem($item);
         }

--- a/src/CXml/Model/Request/OrderRequestHeader.php
+++ b/src/CXml/Model/Request/OrderRequestHeader.php
@@ -150,6 +150,11 @@ class OrderRequestHeader
         return $this->contacts;
     }
 
+    public function setSupplierOrderInfo(SupplierOrderInfo $supplierOrderInfo): void
+    {
+        $this->supplierOrderInfo = $supplierOrderInfo;
+    }
+
     public function getSupplierOrderInfo(): ?SupplierOrderInfo
     {
         return $this->supplierOrderInfo;

--- a/src/CXml/Model/Request/PunchOutSetupRequest.php
+++ b/src/CXml/Model/Request/PunchOutSetupRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXml\Model\Request;
 
+use Assert\Assertion;
 use CXml\Model\ItemOut;
 use CXml\Model\SelectedItem;
 use CXml\Model\ShipTo;
@@ -52,6 +53,8 @@ class PunchOutSetupRequest implements RequestPayloadInterface
 
     public function addItems(array $items): self
     {
+        Assertion::allIsInstanceOf($items, ItemOut::class);
+
         foreach ($items as $item) {
             $this->addItem($item);
         }

--- a/src/CXml/Model/Trait/CommentsTrait.php
+++ b/src/CXml/Model/Trait/CommentsTrait.php
@@ -56,6 +56,7 @@ trait CommentsTrait
                 if (null === $comment->value) {
                     continue;
                 }
+
                 if ('' === $comment->value) {
                     continue;
                 }

--- a/src/CXml/Model/Trait/CommentsTrait.php
+++ b/src/CXml/Model/Trait/CommentsTrait.php
@@ -53,9 +53,13 @@ trait CommentsTrait
         if (is_array($comments)) {
             Assertion::allIsInstanceOf($comments, Comment::class);
             foreach ($comments as $comment) {
-                if (null === $comment->value || '' === $comment->value) {
+                if (null === $comment->value) {
                     continue;
                 }
+                if ('' === $comment->value) {
+                    continue;
+                }
+
                 $commentStrings[] = $comment->value;
             }
         }

--- a/src/CXml/Model/Trait/CommentsTrait.php
+++ b/src/CXml/Model/Trait/CommentsTrait.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXml\Model\Trait;
 
+use Assert\Assertion;
 use CXml\Model\Comment;
 use JMS\Serializer\Annotation as Serializer;
 
@@ -50,7 +51,11 @@ trait CommentsTrait
 
         $comments = $this->getComments();
         if (is_array($comments)) {
+            Assertion::allIsInstanceOf($comments, Comment::class);
             foreach ($comments as $comment) {
+                if (null === $comment->value || '' === $comment->value) {
+                    continue;
+                }
                 $commentStrings[] = $comment->value;
             }
         }

--- a/src/CXml/Validation/DtdValidator.php
+++ b/src/CXml/Validation/DtdValidator.php
@@ -27,6 +27,7 @@ readonly class DtdValidator
 
         $pathToDtds = glob($directory . '/*.dtd');
         Assertion::notEmpty($pathToDtds);
+        Assertion::isArray($pathToDtds);
 
         return new self($pathToDtds);
     }
@@ -84,6 +85,8 @@ readonly class DtdValidator
      */
     private function validateAgainstMultipleDtd(array $validateFiles, DOMDocument $old): void
     {
+        Assertion::allString($validateFiles);
+
         foreach ($validateFiles as $validateFile) {
             $dtdInjectedDomDocument = $this->injectDtd($old, $validateFile);
 

--- a/src/CXml/Validation/DtdValidator.php
+++ b/src/CXml/Validation/DtdValidator.php
@@ -27,7 +27,6 @@ readonly class DtdValidator
 
         $pathToDtds = glob($directory . '/*.dtd');
         Assertion::notEmpty($pathToDtds);
-        Assertion::isArray($pathToDtds);
 
         return new self($pathToDtds);
     }

--- a/tests/CXmlTest/Model/SerializerTest.php
+++ b/tests/CXmlTest/Model/SerializerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CXmlTest\Model;
 
+use CXml\Model\ShipTo;
 use CXml\Builder\OrderRequestBuilder;
 use CXml\Model\Address;
 use CXml\Model\BillTo;
@@ -79,40 +80,41 @@ final class SerializerTest extends TestCase
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-			<Header>
-			<From>
+        $expectedXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>admin@acme.com</Identity>
+				<Identity>admin@acme.com</Identity>
 			</Credential>
-			</From>
-			<To>
+		</From>
+		<To>
 			<Credential domain="DUNS">
-			<Identity>012345678</Identity>
+				<Identity>012345678</Identity>
 			</Credential>
-			</To>
-			<Sender>
+		</To>
+		<Sender>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>sysadmin@buyer.com</Identity>
-			<SharedSecret>abracadabra</SharedSecret>
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
 			</Credential>
 			<UserAgent>Network Hub 1.1</UserAgent>
-			</Sender>
-			</Header>
-			<Request>
-			<PunchOutSetupRequest operation="create">
+		</Sender>
+	</Header>
+	<Request>
+		<PunchOutSetupRequest operation="create">
 			<BuyerCookie>nomnom</BuyerCookie>
 			<BrowserFormPost>
-			<URL>https://browserFormPost</URL>
+				<URL>https://browserFormPost</URL>
 			</BrowserFormPost>
 			<SupplierSetup>
-			<URL>https://supplierSetup</URL>
+				<URL>https://supplierSetup</URL>
 			</SupplierSetup>
-			</PunchOutSetupRequest>
-			</Request>
-			</cXML>';
+		</PunchOutSetupRequest>
+	</Request>
+</cXML>
+XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -151,39 +153,40 @@ final class SerializerTest extends TestCase
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML *NOT* copied from cXML Reference Guide
-        $expectedXml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-			<Header>
-			<From>
+        $expectedXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>admin@acme.com</Identity>
+				<Identity>admin@acme.com</Identity>
 			</Credential>
-			</From>
-			<To>
+		</From>
+		<To>
 			<Credential domain="DUNS">
-			<Identity>012345678</Identity>
+				<Identity>012345678</Identity>
 			</Credential>
-			</To>
-			<Sender>
+		</To>
+		<Sender>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>sysadmin@buyer.com</Identity>
-			<SharedSecret>abracadabra</SharedSecret>
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
 			</Credential>
 			<UserAgent>Network Hub 1.1</UserAgent>
-			</Sender>
-			</Header>
-			<Message>
-			<PunchOutOrderMessage>
+		</Sender>
+	</Header>
+	<Message>
+		<PunchOutOrderMessage>
 			<BuyerCookie>34234234ADFSDF234234</BuyerCookie>
 			<PunchOutOrderMessageHeader operationAllowed="create">
-			<Total>
-			<Money currency="USD">763.20</Money>
-			</Total>
+				<Total>
+					<Money currency="USD">763.20</Money>
+				</Total>
 			</PunchOutOrderMessageHeader>
-			</PunchOutOrderMessage>
-			</Message>
-			</cXML>';
+		</PunchOutOrderMessage>
+	</Message>
+</cXML>
+XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -204,26 +207,28 @@ final class SerializerTest extends TestCase
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML timestamp="2001-01-08T10:47:01-08:00" payloadID="978979621537--4882920031100014936@206.251.25.169">
-			<Response>
-			<Status code="200" text="OK">Ping Response CXml</Status>
-			</Response>
-			</cXML>';
+        $expectedXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML timestamp="2001-01-08T10:47:01-08:00" payloadID="978979621537--4882920031100014936@206.251.25.169">
+	<Response>
+		<Status code="200" text="OK">Ping Response CXml</Status>
+	</Response>
+</cXML>
+XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
     public function testDeserialize(): void
     {
-        $xml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
-			<Response>
-			<Status code="200" text="OK">Ping Response CXml</Status>
-			</Response>
-			</cXML>';
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
+	<Response>
+		<Status code="200" text="OK">Ping Response CXml</Status>
+	</Response>
+</cXML>
+XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xml);
@@ -239,37 +244,40 @@ final class SerializerTest extends TestCase
      */
     public function testDeserializeWithMillisecondsAndTimezone(): void
     {
-        $xmlIn =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML timestamp="2022-06-07T10:09:56.728+00:00" payloadID="x.y.z">
-			<Response>
-			<Status code="200" text="OK">Ping Response CXml</Status>
-			</Response>
-			</cXML>';
+        $xmlIn = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML timestamp="2022-06-07T10:09:56.728+00:00" payloadID="x.y.z">
+	<Response>
+		<Status code="200" text="OK">Ping Response CXml</Status>
+	</Response>
+</cXML>
+XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
 
         $actual = $serializer->serialize($cXml);
-        $xmlOut =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
-			<Response>
-			<Status code="200" text="OK">Ping Response CXml</Status>
-			</Response>
-			</cXML>';
+        $xmlOut = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
+	<Response>
+		<Status code="200" text="OK">Ping Response CXml</Status>
+	</Response>
+</cXML>
+XML;
         $this->assertXmlStringEqualsXmlString($xmlOut, $actual);
     }
 
     public function testDeserializeWithMillisecondsNoTimezone(): void
     {
-        $xmlIn =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML timestamp="2022-06-07T10:09:56.728" payloadID="x.y.z">
-			<Response>
-			<Status code="200" text="OK">Ping Response CXml</Status>
-			</Response>
-			</cXML>';
+        $xmlIn = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML timestamp="2022-06-07T10:09:56.728" payloadID="x.y.z">
+	<Response>
+		<Status code="200" text="OK">Ping Response CXml</Status>
+	</Response>
+</cXML>
+XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
@@ -279,23 +287,20 @@ final class SerializerTest extends TestCase
 
     public function testDeserializeWithDateTimeForDate(): void
     {
-        $xmlIn =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
-			<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
-			<Header>
-			</Header>
-			<Request deploymentMode="test">
-			  <OrderRequest>
-			    <ItemOut quantity="1" requestedDeliveryDate="2023-02-25T02:30:00-08:00" lineNumber="1">
-			    </ItemOut>
-			    <ItemOut quantity="2" requestedDeliveryDate="2023-02-26" lineNumber="2">
-			    </ItemOut>
-			    <ItemOut quantity="3" lineNumber="3">
-			    </ItemOut>
-   			  </OrderRequest>
-			</Request>
-			</cXML>';
+        $xmlIn = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
+<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
+	<Header></Header>
+	<Request deploymentMode="test">
+		<OrderRequest>
+			<ItemOut quantity="1" requestedDeliveryDate="2023-02-25T02:30:00-08:00" lineNumber="1"></ItemOut>
+			<ItemOut quantity="2" requestedDeliveryDate="2023-02-26" lineNumber="2"></ItemOut>
+			<ItemOut quantity="3" lineNumber="3"></ItemOut>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
@@ -316,19 +321,18 @@ final class SerializerTest extends TestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $xmlIn =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
-			<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
-			<Header>
-			</Header>
-			<Request deploymentMode="test">
-			  <OrderRequest>
-			    <ItemOut quantity="1" requestedDeliveryDate="invalid" lineNumber="1">
-			    </ItemOut>
-   			  </OrderRequest>
-			</Request>
-			</cXML>';
+        $xmlIn = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
+<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
+	<Header></Header>
+	<Request deploymentMode="test">
+		<OrderRequest>
+			<ItemOut quantity="1" requestedDeliveryDate="invalid" lineNumber="1"></ItemOut>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
 
         $serializer = Serializer::create();
         $serializer->deserialize($xmlIn);
@@ -370,43 +374,44 @@ final class SerializerTest extends TestCase
 
         $actualXml = Serializer::create()->serialize($msg);
 
-        $expectedXml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-			<Header>
-			<From>
+        $expectedXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>admin@acme.com</Identity>
+				<Identity>admin@acme.com</Identity>
 			</Credential>
-			</From>
-			<To>
+		</From>
+		<To>
 			<Credential domain="DUNS">
-			<Identity>012345678</Identity>
+				<Identity>012345678</Identity>
 			</Credential>
-			</To>
-			<Sender>
+		</To>
+		<Sender>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>sysadmin@buyer.com</Identity>
-			<SharedSecret>abracadabra</SharedSecret>
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
 			</Credential>
 			<UserAgent>Network Hub 1.1</UserAgent>
-			</Sender>
-			</Header>
-			<Request>
-				<OrderRequest>
-				  <OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
-					<Total>
-					  <Money currency="EUR">0.00</Money>
-					</Total>
-					<BillTo>
-					  <Address>
+		</Sender>
+	</Header>
+	<Request>
+		<OrderRequest>
+			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
+				<Total>
+					<Money currency="EUR">0.00</Money>
+				</Total>
+				<BillTo>
+					<Address>
 						<Name xml:lang="en">name</Name>
-					  </Address>
-					</BillTo>
-				  </OrderRequestHeader>
-				</OrderRequest>
-			</Request>
-			</cXML>';
+					</Address>
+				</BillTo>
+			</OrderRequestHeader>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -425,43 +430,44 @@ final class SerializerTest extends TestCase
 
     public function testDeserializeNullProperty(): void
     {
-        $xml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-			<Header>
-			<From>
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>admin@acme.com</Identity>
+				<Identity>admin@acme.com</Identity>
 			</Credential>
-			</From>
-			<To>
+		</From>
+		<To>
 			<Credential domain="DUNS">
-			<Identity>012345678</Identity>
+				<Identity>012345678</Identity>
 			</Credential>
-			</To>
-			<Sender>
+		</To>
+		<Sender>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>sysadmin@buyer.com</Identity>
-			<SharedSecret>abracadabra</SharedSecret>
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
 			</Credential>
 			<UserAgent>Network Hub 1.1</UserAgent>
-			</Sender>
-			</Header>
-			<Request>
-				<OrderRequest>
-				  <OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
-					<Total>
-					  <Money currency="EUR">0.00</Money>
-					</Total>
-					<BillTo>
-					  <Address>
+		</Sender>
+	</Header>
+	<Request>
+		<OrderRequest>
+			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
+				<Total>
+					<Money currency="EUR">0.00</Money>
+				</Total>
+				<BillTo>
+					<Address>
 						<Name xml:lang="en">name</Name>
-					  </Address>
-					</BillTo>
-				  </OrderRequestHeader>
-				</OrderRequest>
-			</Request>
-			</cXML>';
+					</Address>
+				</BillTo>
+			</OrderRequestHeader>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
 
         $cxml = Serializer::create()->deserialize($xml);
 
@@ -470,7 +476,7 @@ final class SerializerTest extends TestCase
 
         // Error: Typed property CXml\Model\Request\OrderRequestHeader::$shipTo must not be accessed before initialization
         $shipTo = $orderRequest->orderRequestHeader->getShipTo();
-        $this->assertNull($shipTo);
+        $this->assertNotInstanceOf(ShipTo::class, $shipTo);
     }
 
     public function testSerializePayment(): void
@@ -569,71 +575,137 @@ final class SerializerTest extends TestCase
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml =
-            '<?xml version="1.0" encoding="UTF-8"?>
-			<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-			<Header>
-			<From>
+        $expectedXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>admin@acme.com</Identity>
+				<Identity>admin@acme.com</Identity>
 			</Credential>
-			</From>
-			<To>
+		</From>
+		<To>
 			<Credential domain="DUNS">
-			<Identity>012345678</Identity>
+				<Identity>012345678</Identity>
 			</Credential>
-			</To>
-			<Sender>
+		</To>
+		<Sender>
 			<Credential domain="AribaNetworkUserId">
-			<Identity>sysadmin@buyer.com</Identity>
-			<SharedSecret>abracadabra</SharedSecret>
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
 			</Credential>
 			<UserAgent>Network Hub 1.1</UserAgent>
-			</Sender>
-			</Header>
-			<Request>
-        <OrderRequest>
-     <OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
-       <Total>
-         <Money currency="EUR">85.00</Money>
-       </Total>
-       <BillTo>
-         <Address>
-           <Name xml:lang="en">Acme GmbH</Name>
-           <PostalAddress name="default">
-             <Street>Acme Street 18</Street>
-             <City>Solingen</City>
-             <PostalCode>42699</PostalCode>
-             <Country isoCountryCode="DE">Deutschland</Country>
-           </PostalAddress>
-           <Phone name="company">
-             <TelephoneNumber>
-               <CountryCode isoCountryCode="DE">49</CountryCode>
-               <AreaOrCityCode>761</AreaOrCityCode>
-               <Number>1234567</Number>
-             </TelephoneNumber>
-           </Phone>
-         </Address>
-       </BillTo>
-        <Payment>
-          <PaymentReference method="voucher">
-            <Money currency="EUR">10.00</Money>          
-            <IdReference domain="code" identifier="ABC123"/>
-          </PaymentReference>
-          <PaymentReference method="creditcard" provider="stripe">
-            <Money currency="EUR">10.00</Money>          
-            <IdReference domain="charge-id" identifier="ch..."/>
-            <Extrinsic name="some">value</Extrinsic>
-          </PaymentReference>
-        </Payment>
-     </OrderRequestHeader>
-   </OrderRequest>
-			</Request>
-			</cXML>';
+		</Sender>
+	</Header>
+	<Request>
+		<OrderRequest>
+			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
+				<Total>
+					<Money currency="EUR">85.00</Money>
+				</Total>
+				<BillTo>
+					<Address>
+						<Name xml:lang="en">Acme GmbH</Name>
+						<PostalAddress name="default">
+							<Street>Acme Street 18</Street>
+							<City>Solingen</City>
+							<PostalCode>42699</PostalCode>
+							<Country isoCountryCode="DE">Deutschland</Country>
+						</PostalAddress>
+						<Phone name="company">
+							<TelephoneNumber>
+								<CountryCode isoCountryCode="DE">49</CountryCode>
+								<AreaOrCityCode>761</AreaOrCityCode>
+								<Number>1234567</Number>
+							</TelephoneNumber>
+						</Phone>
+					</Address>
+				</BillTo>
+				<Payment>
+					<PaymentReference method="voucher">
+						<Money currency="EUR">10.00</Money>
+						<IdReference domain="code" identifier="ABC123"/>
+					</PaymentReference>
+					<PaymentReference method="creditcard" provider="stripe">
+						<Money currency="EUR">10.00</Money>
+						<IdReference domain="charge-id" identifier="ch..."/>
+						<Extrinsic name="some">value</Extrinsic>
+					</PaymentReference>
+				</Payment>
+			</OrderRequestHeader>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
+    }
 
-        $cxml = Serializer::create()->deserialize($actualXml);
+    public function testDeserializePayment(): void
+    {
+        $xml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+	<Header>
+		<From>
+			<Credential domain="AribaNetworkUserId">
+				<Identity>admin@acme.com</Identity>
+			</Credential>
+		</From>
+		<To>
+			<Credential domain="DUNS">
+				<Identity>012345678</Identity>
+			</Credential>
+		</To>
+		<Sender>
+			<Credential domain="AribaNetworkUserId">
+				<Identity>sysadmin@buyer.com</Identity>
+				<SharedSecret>abracadabra</SharedSecret>
+			</Credential>
+			<UserAgent>Network Hub 1.1</UserAgent>
+		</Sender>
+	</Header>
+	<Request>
+		<OrderRequest>
+			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
+				<Total>
+					<Money currency="EUR">85.00</Money>
+				</Total>
+				<BillTo>
+					<Address>
+						<Name xml:lang="en">Acme GmbH</Name>
+						<PostalAddress name="default">
+							<Street>Acme Street 18</Street>
+							<City>Solingen</City>
+							<PostalCode>42699</PostalCode>
+							<Country isoCountryCode="DE">Deutschland</Country>
+						</PostalAddress>
+						<Phone name="company">
+							<TelephoneNumber>
+								<CountryCode isoCountryCode="DE">49</CountryCode>
+								<AreaOrCityCode>761</AreaOrCityCode>
+								<Number>1234567</Number>
+							</TelephoneNumber>
+						</Phone>
+					</Address>
+				</BillTo>
+				<Payment>
+					<PaymentReference method="voucher">
+						<Money currency="EUR">10.00</Money>
+						<IdReference domain="code" identifier="ABC123"/>
+					</PaymentReference>
+					<PaymentReference method="creditcard" provider="stripe">
+						<Money currency="EUR">10.00</Money>
+						<IdReference domain="charge-id" identifier="ch..."/>
+						<Extrinsic name="some">value</Extrinsic>
+					</PaymentReference>
+				</Payment>
+			</OrderRequestHeader>
+		</OrderRequest>
+	</Request>
+</cXML>
+XML;
+        $cxml = Serializer::create()->deserialize($xml);
         $deserializedPayment = $cxml->request->payload->orderRequestHeader->getPayment();
 
         $this->assertNotNull($deserializedPayment);
@@ -642,4 +714,5 @@ final class SerializerTest extends TestCase
         $this->assertSame('voucher', $deserializedPayment->paymentImpl[0]->method);
         $this->assertSame('creditcard', $deserializedPayment->paymentImpl[1]->method);
     }
+
 }

--- a/tests/CXmlTest/Model/SerializerTest.php
+++ b/tests/CXmlTest/Model/SerializerTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace CXmlTest\Model;
 
-use CXml\Model\ShipTo;
 use CXml\Builder\OrderRequestBuilder;
 use CXml\Model\Address;
 use CXml\Model\BillTo;
@@ -31,6 +30,7 @@ use CXml\Model\Request\OrderRequestHeader;
 use CXml\Model\Request\PunchOutSetupRequest;
 use CXml\Model\Request\Request;
 use CXml\Model\Response\Response;
+use CXml\Model\ShipTo;
 use CXml\Model\Status;
 use CXml\Model\TelephoneNumber;
 use CXml\Serializer;
@@ -80,41 +80,41 @@ final class SerializerTest extends TestCase
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Request>
-		<PunchOutSetupRequest operation="create">
-			<BuyerCookie>nomnom</BuyerCookie>
-			<BrowserFormPost>
-				<URL>https://browserFormPost</URL>
-			</BrowserFormPost>
-			<SupplierSetup>
-				<URL>https://supplierSetup</URL>
-			</SupplierSetup>
-		</PunchOutSetupRequest>
-	</Request>
-</cXML>
-XML;
+        $expectedXml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Request>
+            		<PunchOutSetupRequest operation="create">
+            			<BuyerCookie>nomnom</BuyerCookie>
+            			<BrowserFormPost>
+            				<URL>https://browserFormPost</URL>
+            			</BrowserFormPost>
+            			<SupplierSetup>
+            				<URL>https://supplierSetup</URL>
+            			</SupplierSetup>
+            		</PunchOutSetupRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -153,40 +153,40 @@ XML;
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML *NOT* copied from cXML Reference Guide
-        $expectedXml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Message>
-		<PunchOutOrderMessage>
-			<BuyerCookie>34234234ADFSDF234234</BuyerCookie>
-			<PunchOutOrderMessageHeader operationAllowed="create">
-				<Total>
-					<Money currency="USD">763.20</Money>
-				</Total>
-			</PunchOutOrderMessageHeader>
-		</PunchOutOrderMessage>
-	</Message>
-</cXML>
-XML;
+        $expectedXml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Message>
+            		<PunchOutOrderMessage>
+            			<BuyerCookie>34234234ADFSDF234234</BuyerCookie>
+            			<PunchOutOrderMessageHeader operationAllowed="create">
+            				<Total>
+            					<Money currency="USD">763.20</Money>
+            				</Total>
+            			</PunchOutOrderMessageHeader>
+            		</PunchOutOrderMessage>
+            	</Message>
+            </cXML>
+            XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -207,28 +207,28 @@ XML;
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML timestamp="2001-01-08T10:47:01-08:00" payloadID="978979621537--4882920031100014936@206.251.25.169">
-	<Response>
-		<Status code="200" text="OK">Ping Response CXml</Status>
-	</Response>
-</cXML>
-XML;
+        $expectedXml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML timestamp="2001-01-08T10:47:01-08:00" payloadID="978979621537--4882920031100014936@206.251.25.169">
+            	<Response>
+            		<Status code="200" text="OK">Ping Response CXml</Status>
+            	</Response>
+            </cXML>
+            XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
     public function testDeserialize(): void
     {
-        $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
-	<Response>
-		<Status code="200" text="OK">Ping Response CXml</Status>
-	</Response>
-</cXML>
-XML;
+        $xml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
+            	<Response>
+            		<Status code="200" text="OK">Ping Response CXml</Status>
+            	</Response>
+            </cXML>
+            XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xml);
@@ -244,40 +244,40 @@ XML;
      */
     public function testDeserializeWithMillisecondsAndTimezone(): void
     {
-        $xmlIn = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML timestamp="2022-06-07T10:09:56.728+00:00" payloadID="x.y.z">
-	<Response>
-		<Status code="200" text="OK">Ping Response CXml</Status>
-	</Response>
-</cXML>
-XML;
+        $xmlIn = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML timestamp="2022-06-07T10:09:56.728+00:00" payloadID="x.y.z">
+            	<Response>
+            		<Status code="200" text="OK">Ping Response CXml</Status>
+            	</Response>
+            </cXML>
+            XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
 
         $actual = $serializer->serialize($cXml);
-        $xmlOut = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
-	<Response>
-		<Status code="200" text="OK">Ping Response CXml</Status>
-	</Response>
-</cXML>
-XML;
+        $xmlOut = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML timestamp="2022-06-07T10:09:56+00:00" payloadID="x.y.z">
+            	<Response>
+            		<Status code="200" text="OK">Ping Response CXml</Status>
+            	</Response>
+            </cXML>
+            XML;
         $this->assertXmlStringEqualsXmlString($xmlOut, $actual);
     }
 
     public function testDeserializeWithMillisecondsNoTimezone(): void
     {
-        $xmlIn = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML timestamp="2022-06-07T10:09:56.728" payloadID="x.y.z">
-	<Response>
-		<Status code="200" text="OK">Ping Response CXml</Status>
-	</Response>
-</cXML>
-XML;
+        $xmlIn = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML timestamp="2022-06-07T10:09:56.728" payloadID="x.y.z">
+            	<Response>
+            		<Status code="200" text="OK">Ping Response CXml</Status>
+            	</Response>
+            </cXML>
+            XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
@@ -287,20 +287,20 @@ XML;
 
     public function testDeserializeWithDateTimeForDate(): void
     {
-        $xmlIn = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
-<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
-	<Header></Header>
-	<Request deploymentMode="test">
-		<OrderRequest>
-			<ItemOut quantity="1" requestedDeliveryDate="2023-02-25T02:30:00-08:00" lineNumber="1"></ItemOut>
-			<ItemOut quantity="2" requestedDeliveryDate="2023-02-26" lineNumber="2"></ItemOut>
-			<ItemOut quantity="3" lineNumber="3"></ItemOut>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $xmlIn = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
+            <cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
+            	<Header></Header>
+            	<Request deploymentMode="test">
+            		<OrderRequest>
+            			<ItemOut quantity="1" requestedDeliveryDate="2023-02-25T02:30:00-08:00" lineNumber="1"></ItemOut>
+            			<ItemOut quantity="2" requestedDeliveryDate="2023-02-26" lineNumber="2"></ItemOut>
+            			<ItemOut quantity="3" lineNumber="3"></ItemOut>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $serializer = Serializer::create();
         $cXml = $serializer->deserialize($xmlIn);
@@ -321,18 +321,18 @@ XML;
     {
         $this->expectException(RuntimeException::class);
 
-        $xmlIn = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
-<cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
-	<Header></Header>
-	<Request deploymentMode="test">
-		<OrderRequest>
-			<ItemOut quantity="1" requestedDeliveryDate="invalid" lineNumber="1"></ItemOut>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $xmlIn = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE cXML SYSTEM "http://xml.cxml.org/schemas/cXML/1.2.044/cXML.dtd">
+            <cXML payloadID="1676913078755.23986034.000017504@6/lkmlPq0GFws44XIhyDt9yjJb8=" timestamp="2023-02-20T09:11:18-08:00" version="1.2.044" xml:lang="en-US">
+            	<Header></Header>
+            	<Request deploymentMode="test">
+            		<OrderRequest>
+            			<ItemOut quantity="1" requestedDeliveryDate="invalid" lineNumber="1"></ItemOut>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $serializer = Serializer::create();
         $serializer->deserialize($xmlIn);
@@ -374,44 +374,44 @@ XML;
 
         $actualXml = Serializer::create()->serialize($msg);
 
-        $expectedXml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Request>
-		<OrderRequest>
-			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
-				<Total>
-					<Money currency="EUR">0.00</Money>
-				</Total>
-				<BillTo>
-					<Address>
-						<Name xml:lang="en">name</Name>
-					</Address>
-				</BillTo>
-			</OrderRequestHeader>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $expectedXml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Request>
+            		<OrderRequest>
+            			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
+            				<Total>
+            					<Money currency="EUR">0.00</Money>
+            				</Total>
+            				<BillTo>
+            					<Address>
+            						<Name xml:lang="en">name</Name>
+            					</Address>
+            				</BillTo>
+            			</OrderRequestHeader>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
@@ -430,44 +430,44 @@ XML;
 
     public function testDeserializeNullProperty(): void
     {
-        $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Request>
-		<OrderRequest>
-			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
-				<Total>
-					<Money currency="EUR">0.00</Money>
-				</Total>
-				<BillTo>
-					<Address>
-						<Name xml:lang="en">name</Name>
-					</Address>
-				</BillTo>
-			</OrderRequestHeader>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $xml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Request>
+            		<OrderRequest>
+            			<OrderRequestHeader orderDate="2000-01-01" orderID="order-id" type="new">
+            				<Total>
+            					<Money currency="EUR">0.00</Money>
+            				</Total>
+            				<BillTo>
+            					<Address>
+            						<Name xml:lang="en">name</Name>
+            					</Address>
+            				</BillTo>
+            			</OrderRequestHeader>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $cxml = Serializer::create()->deserialize($xml);
 
@@ -575,136 +575,136 @@ XML;
         $actualXml = Serializer::create()->serialize($msg);
 
         // XML copied from cXML Reference Guide
-        $expectedXml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Request>
-		<OrderRequest>
-			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
-				<Total>
-					<Money currency="EUR">85.00</Money>
-				</Total>
-				<BillTo>
-					<Address>
-						<Name xml:lang="en">Acme GmbH</Name>
-						<PostalAddress name="default">
-							<Street>Acme Street 18</Street>
-							<City>Solingen</City>
-							<PostalCode>42699</PostalCode>
-							<Country isoCountryCode="DE">Deutschland</Country>
-						</PostalAddress>
-						<Phone name="company">
-							<TelephoneNumber>
-								<CountryCode isoCountryCode="DE">49</CountryCode>
-								<AreaOrCityCode>761</AreaOrCityCode>
-								<Number>1234567</Number>
-							</TelephoneNumber>
-						</Phone>
-					</Address>
-				</BillTo>
-				<Payment>
-					<PaymentReference method="voucher">
-						<Money currency="EUR">10.00</Money>
-						<IdReference domain="code" identifier="ABC123"/>
-					</PaymentReference>
-					<PaymentReference method="creditcard" provider="stripe">
-						<Money currency="EUR">10.00</Money>
-						<IdReference domain="charge-id" identifier="ch..."/>
-						<Extrinsic name="some">value</Extrinsic>
-					</PaymentReference>
-				</Payment>
-			</OrderRequestHeader>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $expectedXml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Request>
+            		<OrderRequest>
+            			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
+            				<Total>
+            					<Money currency="EUR">85.00</Money>
+            				</Total>
+            				<BillTo>
+            					<Address>
+            						<Name xml:lang="en">Acme GmbH</Name>
+            						<PostalAddress name="default">
+            							<Street>Acme Street 18</Street>
+            							<City>Solingen</City>
+            							<PostalCode>42699</PostalCode>
+            							<Country isoCountryCode="DE">Deutschland</Country>
+            						</PostalAddress>
+            						<Phone name="company">
+            							<TelephoneNumber>
+            								<CountryCode isoCountryCode="DE">49</CountryCode>
+            								<AreaOrCityCode>761</AreaOrCityCode>
+            								<Number>1234567</Number>
+            							</TelephoneNumber>
+            						</Phone>
+            					</Address>
+            				</BillTo>
+            				<Payment>
+            					<PaymentReference method="voucher">
+            						<Money currency="EUR">10.00</Money>
+            						<IdReference domain="code" identifier="ABC123"/>
+            					</PaymentReference>
+            					<PaymentReference method="creditcard" provider="stripe">
+            						<Money currency="EUR">10.00</Money>
+            						<IdReference domain="charge-id" identifier="ch..."/>
+            						<Extrinsic name="some">value</Extrinsic>
+            					</PaymentReference>
+            				</Payment>
+            			</OrderRequestHeader>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
 
         $this->assertXmlStringEqualsXmlString($expectedXml, $actualXml);
     }
 
     public function testDeserializePayment(): void
     {
-        $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
-	<Header>
-		<From>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>admin@acme.com</Identity>
-			</Credential>
-		</From>
-		<To>
-			<Credential domain="DUNS">
-				<Identity>012345678</Identity>
-			</Credential>
-		</To>
-		<Sender>
-			<Credential domain="AribaNetworkUserId">
-				<Identity>sysadmin@buyer.com</Identity>
-				<SharedSecret>abracadabra</SharedSecret>
-			</Credential>
-			<UserAgent>Network Hub 1.1</UserAgent>
-		</Sender>
-	</Header>
-	<Request>
-		<OrderRequest>
-			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
-				<Total>
-					<Money currency="EUR">85.00</Money>
-				</Total>
-				<BillTo>
-					<Address>
-						<Name xml:lang="en">Acme GmbH</Name>
-						<PostalAddress name="default">
-							<Street>Acme Street 18</Street>
-							<City>Solingen</City>
-							<PostalCode>42699</PostalCode>
-							<Country isoCountryCode="DE">Deutschland</Country>
-						</PostalAddress>
-						<Phone name="company">
-							<TelephoneNumber>
-								<CountryCode isoCountryCode="DE">49</CountryCode>
-								<AreaOrCityCode>761</AreaOrCityCode>
-								<Number>1234567</Number>
-							</TelephoneNumber>
-						</Phone>
-					</Address>
-				</BillTo>
-				<Payment>
-					<PaymentReference method="voucher">
-						<Money currency="EUR">10.00</Money>
-						<IdReference domain="code" identifier="ABC123"/>
-					</PaymentReference>
-					<PaymentReference method="creditcard" provider="stripe">
-						<Money currency="EUR">10.00</Money>
-						<IdReference domain="charge-id" identifier="ch..."/>
-						<Extrinsic name="some">value</Extrinsic>
-					</PaymentReference>
-				</Payment>
-			</OrderRequestHeader>
-		</OrderRequest>
-	</Request>
-</cXML>
-XML;
+        $xml = <<<'XML'
+            <?xml version="1.0" encoding="UTF-8"?>
+            <cXML payloadID="payload-id" timestamp="2000-01-01T00:00:00+00:00">
+            	<Header>
+            		<From>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>admin@acme.com</Identity>
+            			</Credential>
+            		</From>
+            		<To>
+            			<Credential domain="DUNS">
+            				<Identity>012345678</Identity>
+            			</Credential>
+            		</To>
+            		<Sender>
+            			<Credential domain="AribaNetworkUserId">
+            				<Identity>sysadmin@buyer.com</Identity>
+            				<SharedSecret>abracadabra</SharedSecret>
+            			</Credential>
+            			<UserAgent>Network Hub 1.1</UserAgent>
+            		</Sender>
+            	</Header>
+            	<Request>
+            		<OrderRequest>
+            			<OrderRequestHeader orderDate="2000-10-12T18:41:29-08:00" orderID="DO1234" type="new">
+            				<Total>
+            					<Money currency="EUR">85.00</Money>
+            				</Total>
+            				<BillTo>
+            					<Address>
+            						<Name xml:lang="en">Acme GmbH</Name>
+            						<PostalAddress name="default">
+            							<Street>Acme Street 18</Street>
+            							<City>Solingen</City>
+            							<PostalCode>42699</PostalCode>
+            							<Country isoCountryCode="DE">Deutschland</Country>
+            						</PostalAddress>
+            						<Phone name="company">
+            							<TelephoneNumber>
+            								<CountryCode isoCountryCode="DE">49</CountryCode>
+            								<AreaOrCityCode>761</AreaOrCityCode>
+            								<Number>1234567</Number>
+            							</TelephoneNumber>
+            						</Phone>
+            					</Address>
+            				</BillTo>
+            				<Payment>
+            					<PaymentReference method="voucher">
+            						<Money currency="EUR">10.00</Money>
+            						<IdReference domain="code" identifier="ABC123"/>
+            					</PaymentReference>
+            					<PaymentReference method="creditcard" provider="stripe">
+            						<Money currency="EUR">10.00</Money>
+            						<IdReference domain="charge-id" identifier="ch..."/>
+            						<Extrinsic name="some">value</Extrinsic>
+            					</PaymentReference>
+            				</Payment>
+            			</OrderRequestHeader>
+            		</OrderRequest>
+            	</Request>
+            </cXML>
+            XML;
         $cxml = Serializer::create()->deserialize($xml);
         $deserializedPayment = $cxml->request->payload->orderRequestHeader->getPayment();
 
@@ -714,5 +714,4 @@ XML;
         $this->assertSame('voucher', $deserializedPayment->paymentImpl[0]->method);
         $this->assertSame('creditcard', $deserializedPayment->paymentImpl[1]->method);
     }
-
 }


### PR DESCRIPTION
This pull request includes updates to streamline CI workflows, enhance type safety with PHPStan assertions, and improve compatibility by upgrading dependencies. Additionally, it introduces new helper scripts and refactors existing code for better maintainability and clarity.

### CI Workflow Updates:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL59-R71): Updated script commands for CI jobs to use consistent naming conventions (e.g., `composer run phpstan:check` instead of `composer run phpstan`).

### Dependency Upgrades:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L31-R31): Upgraded dependencies to support newer versions, including `beberlei/assert` (`^2.0 || ^3.0`), `phpunit/phpunit` (`^11.0 || ^12.0`), and `phpstan/phpstan` (`^2.0`). Added `phpstan/phpstan-beberlei-assert` for enhanced PHPStan integration. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L31-R31) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L40-R52)

### Helper Scripts:
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L64-R94): Refactored and added new composer scripts, such as `run:all` and `test:all`, to simplify running multiple checks and tests. Introduced platform configuration for PHP version `8.2.28`.

### Type Safety Enhancements:
* [`src/CXml/Builder/OrderRequestBuilder.php`](diffhunk://#diff-d86ea228a4d7fcb5c8361d71dde3fcadfcceec3a304e31b3234704ae4c561433R198-R205): Added PHPStan assertions to validate input types for methods like `shipTo`, `tax`, and `addBusinessPartner`. Ensured stricter type checks for array keys and values. [[1]](diffhunk://#diff-d86ea228a4d7fcb5c8361d71dde3fcadfcceec3a304e31b3234704ae4c561433R198-R205) [[2]](diffhunk://#diff-d86ea228a4d7fcb5c8361d71dde3fcadfcceec3a304e31b3234704ae4c561433R239-R264) [[3]](diffhunk://#diff-d86ea228a4d7fcb5c8361d71dde3fcadfcceec3a304e31b3234704ae4c561433R411-R412)
* [`src/CXml/Builder/ProductActivityMessageBuilder.php`](diffhunk://#diff-bcad69cd9cae4a643def06ca12f2c0ae095345832cffb00084af6047f10b7c0eR47-R48): Incorporated assertions to validate extrinsics keys and values as strings.

### Codebase Refactoring:
* [`rector.php`](diffhunk://#diff-d933a2ad57daa43419b483d3f1ddedaec7aa44933007fead9f9437390f596f4aL47-R47): Changed the cache directory path to `/tmp/rector-cxml-php` for better namespace clarity.
* [`src/CXml/Jms/CXmlWrappingNodeJmsEventSubscriber.php`](diffhunk://#diff-5fc56e519f617c6b1119f95b34401b0d77a4d6687ae92869559defae9fe794c2R170-R174): Improved handling of serialization and deserialization events, including type checks and early returns for invalid inputs. [[1]](diffhunk://#diff-5fc56e519f617c6b1119f95b34401b0d77a4d6687ae92869559defae9fe794c2R170-R174) [[2]](diffhunk://#diff-5fc56e519f617c6b1119f95b34401b0d77a4d6687ae92869559defae9fe794c2R204-R208)